### PR TITLE
Align package license with MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ npm run dev
 
 ## 📄 License
 
-This project is licensed under the ISC License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "swagger-navigator-mcp",
       "version": "1.1.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^12.0.0",
         "@modelcontextprotocol/sdk": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/aaydin-tr/swagger-navigator-mcp/issues"
   },


### PR DESCRIPTION
## Summary

- Align package metadata with the MIT root LICENSE file.
- Update the README license sentence to match LICENSE.

## Validation

- npm ci
- npm test with runInBand: 91 passed
- npm run build
- npm run lint:strict
- npm run format:check
- npm package dry run
- production audit: existing upstream advisories remain 3 low, 6 moderate, 8 high, 1 critical
